### PR TITLE
Fixes repository name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The deploy number for the event - Default: `${GITHUB_RUN_NUMBER}`
 ## Example usage
 
 ```yaml
-uses: opslevel/report-deploy-github-action@v0.1.0
+uses: OpsLevel/report-deploy-github-action@v0.1.0
 with:
   integration_url: ${{ secrets.OL_INTEGRATION_URL }}
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The deploy number for the event - Default: `${GITHUB_RUN_NUMBER}`
 ## Example usage
 
 ```yaml
-uses: opslevel/report-deploy-github-actions@v0.1.0
+uses: opslevel/report-deploy-github-action@v0.1.0
 with:
   integration_url: ${{ secrets.OL_INTEGRATION_URL }}
 ```


### PR DESCRIPTION
The repository name has an extra s

using the example upsets deployment workflows 

:) 