### PR TITLE
Allow dedup id to be set manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The deployer name who created the event - Default: `${GITHUB_ACTOR}`
 
 The deployer email who create the event - Default: ""
 
+### `deduplication_id`
+
+An identifier that can be used to deduplicate deployments - Default: `${GITHUB_RUN_ID}`
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'OpsLevel - Report Deploy'
 author: 'OpsLevel <support@opslevel.com>'
 description: 'Create a deploy event for a service in OpsLevel'
 branding:
-  icon: 'package'  
+  icon: 'package'
   color: 'blue'
 inputs:
   integration_url:
@@ -33,7 +33,10 @@ inputs:
     description: 'The deployer email who created the event'
     required: false
     default: ''
+  deduplication_id:
+    description: 'An identifier that can be used to deduplicate deployments'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 OPSLEVEL_FILE=./opslevel.yml
 if test -f "$OPSLEVEL_FILE"; then
-  OPSLEVEL_SERVICE=$(cat ./opslevel.yml | grep "name:" | awk '{gsub("name:",""); print}' | xargs) 
+  OPSLEVEL_SERVICE=$(cat ./opslevel.yml | grep "name:" | awk '{gsub("name:",""); print}' | xargs)
 fi
 
 cat << EOF | opslevel create deploy -i "${INPUT_INTEGRATION_URL}" -f -
@@ -11,7 +11,7 @@ description: "${INPUT_DESCRIPTION}"
 environment: "${INPUT_ENVIRONMENT}"
 deploy-number: "${INPUT_NUMBER:-${GITHUB_RUN_NUMBER}}"
 deploy-url: "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-dedup-id: "${GITHUB_RUN_ID}"
+dedup-id: "${INPUT_DEDUPLICATION_ID:-${GITHUB_RUN_ID}}"
 deployer:
   name: "${INPUT_DEPLOYER_NAME:-${GITHUB_ACTOR}}"
   email: "${INPUT_DEPLOYER_EMAIL}"


### PR DESCRIPTION
We have some github actions workflows that deploy to multiple environments in a single workflow run. Exposing the dedup id will allow us to set this manually to prevent these deploy notifications from being deduplicated into a single notification.