### PR TITLE
Update OpsLevel CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Upgrade
+
+- bump to use OpsLevel CLI Version v2022.12.22
+
 
 <a name="0.1.0"></a>
 ## [0.1.0] - 2021-06-27

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/opslevel/cli:v0.1.0-beta.1
+FROM public.ecr.aws/opslevel/cli:v2022.12.22
 ENTRYPOINT ["/entrypoint.sh"]
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This updates the OpsLevel CLI version to v2022.12.22, it should have no breaking changes around deploys, but there's CLI improvements that make reporting deploys more resilient.