### PR TITLE
Fix bug with service alias being empty

### DIFF
--- a/.changes/unreleased/Bugfix-20230117-162705.yaml
+++ b/.changes/unreleased/Bugfix-20230117-162705.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix bug with empty service alias
+time: 2023-01-17T16:27:05.506729-05:00

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,3 +18,5 @@ deployer:
 EOF
 
 opslevel create deploy -i "${INPUT_INTEGRATION_URL}" -f .
+
+rm data.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ if test -f "$OPSLEVEL_FILE"; then
   OPSLEVEL_SERVICE=$(cat ./opslevel.yml | grep "name:" | awk '{gsub("name:",""); print}' | xargs)
 fi
 
-cat << EOF | opslevel create deploy -i "${INPUT_INTEGRATION_URL}" -f -
+cat <<EOF > data.yaml
 service: "${INPUT_SERVICE:-${OPSLEVEL_SERVICE:-${GITHUB_REPOSITORY}}}"
 description: "${INPUT_DESCRIPTION}"
 environment: "${INPUT_ENVIRONMENT}"
@@ -16,3 +16,5 @@ deployer:
   name: "${INPUT_DEPLOYER_NAME:-${GITHUB_ACTOR}}"
   email: "${INPUT_DEPLOYER_EMAIL}"
 EOF
+
+opslevel create deploy -i "${INPUT_INTEGRATION_URL}" -f .


### PR DESCRIPTION
Upgrading the OpsLevel CLI version in https://github.com/OpsLevel/report-deploy-github-action/pull/7 introduced a bug where the `service` alias wasn't getting passed into the `opslevel create deploy` command which caused the deploy to not be created.

I'm not sure what's causing the issue, something must have changed with how OpsLevel CLI parses standard input. The fix is to pass input using a file instead of standard input.

Example action run with the old code where `service` isn't set: 

<img width="498" alt="Screen Shot 2023-01-17 at 4 18 36 PM" src="https://user-images.githubusercontent.com/73538852/213014468-b59d561c-4ef1-4e5c-ad47-a0a8d516751d.png">

Example action run with the new code which correctly sets `service`:
<img width="591" alt="Screen Shot 2023-01-17 at 4 17 54 PM" src="https://user-images.githubusercontent.com/73538852/213014584-bf7d97d8-e71a-4c17-a1f3-63f5f6aa2474.png">

Note that I tested the new code by creating a copy of the action in my test repo. I wasn't sure how to reference the action code from my forked branch in my test repo.



