### PR TITLE
Update the Setup Go action to V4

### DIFF
--- a/.changes/unreleased/Feature-20230505-113020.yaml
+++ b/.changes/unreleased/Feature-20230505-113020.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Update actions/setup-go to V4
+time: 2023-05-05T11:30:20.980706-04:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Fetch All Tags
         run: git fetch --force --tags
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Determine Next Version


### PR DESCRIPTION
The latest version of actions/setup-go is V4, there are no breaking changes in these releases and this is only used to perform releases.