### PR TITLE
set goreleaser version 2 in config file, bump version in release work…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           gh release delete ${{ steps.next_version.outputs.version_tag }} || true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5.0.0
+        uses: goreleaser/goreleaser-action@v6.0.0
         with:
           args: release --rm-dist --release-notes=./.changes/${{ steps.next_version.outputs.version_tag }}.md
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: report-deploy-github-action
 builds:
   - skip: true


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `version: 2` to goreleaser config file
Bump `goreleaser/goreleaser-action` to v6 which uses goreleaser v2 by default

- [X] List your changes here
- [ ] Make a `changie` entry, N/A updates release workflow only

## Tophatting

Test locally with `goreleaser release --clean --snapshot`
