### PR TITLE
Fix YAML in data.yaml template

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,11 +67,11 @@ runs:
         echo ::add-mask::$INTEGRATION_URL
         cat <<EOF > data.yaml
         service: "$SERVICE"
-        description": "$DESCRIPTION"
-        environment": "$ENVIRONMENT"
-        deploy-number": "$NUMBER"
-        deploy-url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        dedup-id": "$DEDUPLICATION_ID"
+        description: "$DESCRIPTION"
+        environment: "$ENVIRONMENT"
+        deploy-number: "$NUMBER"
+        deploy-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        dedup-id: "$DEDUPLICATION_ID"
         deployer:
           name: "$DEPLOYER_NAME"
           email: "$DEPLOYER_EMAIL"


### PR DESCRIPTION
All my deployments were coming in with description of  `Event Created by OpsLevel CLI` which appears to be the default message, this was regardless of my input.

After some digging it looks like it's the result of some extra quotes in the YAML template, or at least, removing them resolved the issue for me

I suspect other fields were appearing to be working since the default matches what we were passing.

Example: (two broken, two working)

![image](https://github.com/user-attachments/assets/3e3416a7-9226-4ebb-b098-0ba01f1cd959)