### PR TITLE
Add extra integration url to see difference in OpsLevel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Report Deploy with Docker
         uses: ./
         with:
-          integration_url: ${{ secrets.DEPLOY_INTEGRATION_URL }}
+          integration_url: ${{ secrets.OL_TEST_DEPLOY_URL }}
           service: "report_deploy_github_action"
           use_docker: "true"
       - name: Report Deploy with CLI
         uses: ./
         with:
-          integration_url: ${{ secrets.DEPLOY_INTEGRATION_URL }}
+          integration_url: ${{ secrets.OL_TEST_DEPLOY_URL }}
           service: "report_deploy_github_action"
           use_docker: "false"


### PR DESCRIPTION
Add the secret for a test deploy integration so we can see the difference between real ones in OpsLevel.

<img width="178" alt="Screenshot 2024-10-15 at 5 00 40 PM" src="https://github.com/user-attachments/assets/a3971776-2bc3-46d8-896a-136636e2d229">
